### PR TITLE
Clear middleware on reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "hubot": "2.x"
+    "hubot": ">=2"
   },
   "devDependencies": {
     "coffee-script": "1.9.x"

--- a/src/reload-scripts.coffee
+++ b/src/reload-scripts.coffee
@@ -24,6 +24,9 @@ module.exports = (robot) ->
 
       robot.commands = []
       robot.listeners = []
+      if (robot.middleware)
+        for key in Object.keys robot.middleware
+          robot.middleware[key].stack = []
 
       reloadAllScripts msg, success, (err) ->
         msg.send err


### PR DESCRIPTION
Reloads create duplicates of middleware.

Reproduce by creating middleware that writes to console. Each reload causes an extra console write

Fix by clearing middleware on reload.
